### PR TITLE
Use IRC nick as user ID

### DIFF
--- a/lib/lita/adapters/irc/cinch_plugin.rb
+++ b/lib/lita/adapters/irc/cinch_plugin.rb
@@ -58,7 +58,7 @@ MSG
 
         def user_by_nick(nick)
           Lita.logger.debug("Looking up user with nick: #{nick}.")
-          User.find_by_name(nick) || User.create(SecureRandom.uuid, name: nick)
+          User.find_by_name(nick) || User.create(nick)
         end
       end
     end


### PR DESCRIPTION
Quick and dirty fix to allow us to name IRC users as admins. Mentioned in issue #4.

Can you think of any unintended consequences to this?